### PR TITLE
Fixed resolution of THISDIR so it can correctly find the model.

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -2,17 +2,7 @@
 
 start=`date +%s`
 
-# check if script is started via SLURM or bash
-# if with SLURM: there variable '$SLURM_JOB_ID' will exist
-# `if [ -n $SLURM_JOB_ID ]` checks if $SLURM_JOB_ID is not an empty string
-if [[ -n $SLURM_JOB_ID ]]; then
-    # check the original location through scontrol and $SLURM_JOB_ID
-    THISDIR=$(scontrol show job $SLURM_JOBID | awk -F= '/Command=/{print $2}' | sed -e 's/\s.*$//')
-    THISDIR=$(dirname $THISDIR)
-else
-    # otherwise: started with bash. Get the real location.
-    THISDIR="$( cd "$( dirname "$0" )" && pwd )"
-fi
+THISDIR="$( cd "$( dirname "$0" )" && pwd )"
 
 hn=$(hostname)
 if [[ $hn == "puck4.cluster" ]]; then


### PR DESCRIPTION
When using a slurm script to run the `apply.sh`, if the slurm job script is not inside the `voice-type-classifier` directory, `THISDIR` is set such that it cannot find the `model` sub-directory. To replicate the issue, just create a slurm job script like this one and run it with sbatch:
```{bash}
#!/bin/bash
#SBATCH -p scavenger-gpu --gres=gpu:1
#SBATCH -c 4
#SBATCH -e slurm.err
#SBATCH -o slurm.out
#SBATCH --mem=32G
. ~/.bashrc
conda activate pyannote
/hpc/group/bergelsonlab/su26/voice_type_classifier/apply.sh /hpc/group/bergelsonlab/su26/our_wav --device=gpu
```

If this script is not placed in the parent directory of the `voice-type-classifier` directory, `THISDIR` ends up as `/hpc/group/bergelsonlab/su26`, whereas it should be `/hpc/group/bergelsonlab/su26/voice-type-classifier`. Unless I am missing something, the simpler resolution of `THISDIR` in the else condition is good for slurm too. 
